### PR TITLE
[add] feed Main page layout [add] button components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "comento-hoic",
+  "name": "comento",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -3241,6 +3241,14 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.2.0.tgz",
       "integrity": "sha512-1uIESzroqpaTzt9uX48HO+6gfnKu3RwvWdCcWSrX4csMInJfCo1yvKPNXCwXFRpJqRW25tiASb6No0YH57PXqg=="
     },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -5953,12 +5961,6 @@
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ=="
         }
       }
-    },
-    "eslint-config-prettier": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
-      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
     },
     "eslint-config-react-app": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
+    "axios": "^0.21.1",
+    "node-sass": "^4.0.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -1,1 +1,6 @@
 export const COMENTO_SERVER = 'https://problem.comento.kr';
+
+export const CONTENTS_API = `${COMENTO_SERVER}/api/list`;
+export const FILTER_API = `${COMENTO_SERVER}/api/category`;
+export const ADVERT_API = `${COMENTO_SERVER}/api/ads`;
+export const CONTENTS_DETAIL_API = `${COMENTO_SERVER}/api/view`;

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import Routes from "./Routes"
+import Routes from './Routes';
 
-import "./styles/Reset.scss"
-
+import './styles/reset.scss';
 
 ReactDOM.render(<Routes />, document.getElementById('root'));
-

--- a/src/pages/feed/FeedMain/FeedMain.js
+++ b/src/pages/feed/FeedMain/FeedMain.js
@@ -1,18 +1,123 @@
-import React, { useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
+
+import GreenBtn from '../components/GreenBtn/GreenBtn';
+import SortBtn from '../components/SortBtn/SortBtn';
+import Contents from './components/Contents/Contents';
+import Avert from './components/Advert/Avert';
+
+import { CONTENTS_API, ADVERT_API, FILTER_API } from '../../../config';
 
 import './FeedMain.scss';
 
 function FeedMain() {
+  // 데이터를 받아올 기준
+  const [contentsFilterCondition, setContentsFilterCondition] = useState({
+    page: 1,
+    ord: 'asc',
+    category: 1,
+    limit: 10,
+  });
+  const [advertFilterCondition, setAdvertFilterCondition] = useState({
+    page: 1,
+    limit: 10,
+  });
+
+  // 받아온 데이터
+  const [contentsData, setContentsData] = useState([]);
+  const [advertData, setAdvertData] = useState([]);
+  const [categoryData, setCategoryData] = useState([]);
+
+  // 그외 기능을 위한 상태 값
+  const [selectedAscending, setSelectedAscending] = useState(true);
+
+  useEffect(() => {
+    getContentsList();
+    getAdvertList();
+    getCategoryList();
+  }, []);
+
+  const sortBtnToggle = (e) => {
+    setSelectedAscending(e.target.name === 'asc');
+    if (e.target.name === 'asc') {
+      setContentsFilterCondition({ ...contentsFilterCondition, ord: 'asc' });
+    }
+    if (e.target.name === 'desc') {
+      setContentsFilterCondition({ ...contentsFilterCondition, ord: 'desc' });
+    }
+  };
+
+  const getContentsList = () => {
+    const { page, ord, category, limit } = contentsFilterCondition;
+    axios
+      .get(
+        `${CONTENTS_API}?page=${page}&ord=${ord}&category[]=${category}&limit=${limit}`,
+        {
+          header: {
+            Accept: 'application/json',
+          },
+        }
+      )
+      .then((contents) => setContentsData(contents.data.data))
+      .catch((err) => console.log(err));
+  };
+
+  const getAdvertList = () => {
+    const { page, limit } = advertFilterCondition;
+    axios
+      .get(`${ADVERT_API}?page=${page}&limit=${limit}`, {
+        header: {
+          Accept: 'application/json',
+        },
+      })
+      .then((advert) => setAdvertData(advert.data.data))
+      .catch((err) => console.log(err));
+  };
+
+  const getCategoryList = () => {
+    axios
+      .get(`${FILTER_API}`, {
+        header: {
+          Accept: 'application/json',
+        },
+      })
+      .then((category) => setCategoryData(category.data))
+      .catch((err) => console.log(err));
+  };
 
   return (
-    <div className="FeedMain">
+    <div className="FeedMainWrapper">
       <header>
         <h1>[5월 13일] 유호익</h1>
       </header>
-
-      <aside>
-        <button>로그인</button>
-      </aside>
+      <div className="FeedMain">
+        <div className="mainAsideWrapper">
+          <aside>
+            <GreenBtn btnName="로그인" />
+          </aside>
+          <main>
+            <div className="btnWrapper">
+              <div className="sortBtnBox">
+                <SortBtn
+                  name="asc"
+                  btnName="오름차순"
+                  selectedAscending={selectedAscending}
+                  runFunction={sortBtnToggle}
+                />
+                <SortBtn
+                  name="desc"
+                  btnName="내림차순"
+                  selectedAscending={!selectedAscending}
+                  runFunction={sortBtnToggle}
+                />
+              </div>
+              <button className="filterBtn">필터</button>
+            </div>
+            <Contents />
+            <Avert />
+          </main>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/feed/FeedMain/FeedMain.scss
+++ b/src/pages/feed/FeedMain/FeedMain.scss
@@ -1,21 +1,91 @@
 @import "/src/styles/common.scss";
 
-.FeedMain{
-
+.FeedMainWrapper{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100vw;
+  height: 100vh;
+  font-family: $defaltFont;
+  
   header{
     display: flex;
     align-items: center;
+    width: 100%;
     height: 70px;
-    
+    box-shadow: 0px 1px 5px #00000012;
+
+    @media screen and (max-width: 768px) {
+      width: $mobileWidth;
+      height: 45px;
+    }
+  
     h1{
-      margin-left: 390px;
+      margin-left: 50px;
+      @media screen and (max-width: 768px) {
+        margin-left: 15px;
+        font-size: 16px;
+      }
     }
   }
-  
-  aside{
-    margin-top: 23px;
-    margin-left: 390px;
 
-    
+  .FeedMain{
+    padding-top: 2px;
+
+    @media screen and (max-width: 768px) {
+      width: $mobileWidth;
+      height: 45px;
+      background-color: #EFF0F2;
+      box-shadow: 0px 2px 3px #00000012;
+    }
+
+    .mainAsideWrapper{
+      display: flex;
+
+      aside{
+        margin-left: 50px;
+
+        @media screen and (max-width: 768px) {
+          display: none;
+        }
+      }
+
+      main{
+        padding: 0 30px;
+        
+        @media screen and (max-width: 768px) {
+          padding: 0;
+        }
+
+        .btnWrapper{
+          display: flex;
+          justify-content: space-between;
+          align-items: center;
+          width: 864px;
+          margin-bottom: 15px;  
+
+          @media screen and (max-width: 768px) {
+            width: $mobileWidth;
+            height: 44px;
+            padding: 0 15px;
+            margin-bottom: 0;  
+            border-bottom: 1px solid #0000000D;
+          }
+
+          .sortBtnBox{
+            display: flex;
+          }
+
+          .filterBtn{
+            width: 48px;
+            height: 24px;
+            color: #ADB5BD;
+            background-color: $defaltWhiteColor;   
+            border: 1px solid #E1E4E7;
+            border-radius: 3px;     
+          }
+        }      
+      }
+    }
   }
 }

--- a/src/pages/feed/FeedMain/components/Advert/Avert.js
+++ b/src/pages/feed/FeedMain/components/Advert/Avert.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import './Avert.scss';
+
+function Avert({ runFunction, imgFile }) {
+  return (
+    <article className="Avert">
+      <h2>sponsered</h2>
+      <div className="postImgBox">
+        <img
+          src={`https://cdn.comento.kr/assignment/${imgFile}`}
+          alt="광고이미지"
+        />
+        <div className="post">
+          <h3>찌워니 바부</h3>
+          <p>contents</p>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export default Avert;

--- a/src/pages/feed/FeedMain/components/Advert/Avert.scss
+++ b/src/pages/feed/FeedMain/components/Advert/Avert.scss
@@ -1,0 +1,78 @@
+@import "/src/styles/common.scss";
+
+.Avert{
+  width: 864px;
+  height: 255px;
+  padding: 20px;
+  margin-bottom: 30px;
+  border: 1px solid #E1E4E7;
+  border-radius: 5px;
+
+  @media screen and (max-width: 768px) {
+    display: flex;
+    flex-direction: column;
+    width: $mobileWidth;
+    height: 381px;
+    padding: $mobilePadding;
+    border: none;
+    border-radius: 0;
+    box-shadow: 0px 5px 10px #0000000D;
+  }
+  
+  h2{
+    padding-bottom: 10px;
+    color: #ADB5BD;
+    font: normal normal normal 13px/25px $defaltFont;
+  }
+  
+  .postImgBox{
+    display: flex;
+    margin-top: 5px;
+
+    @media screen and (max-width: 768px) {
+      display: flex;
+      flex-direction: column;
+    }
+
+    img{
+      width:310px; 
+      height:179px;
+      background-color: aqua;
+
+      @media screen and (max-width: 768px) {
+        width: 345px;
+      }
+    }
+
+    .post{
+      margin-left: 15px;
+
+      @media screen and (max-width: 768px) {
+        margin-left: 0;
+        margin-top: 20px;
+      }
+
+      h3{
+        font: normal normal bold 18px/28px $defaltFont;
+        overflow: hidden;
+
+        @media screen and (max-width: 768px) {
+          height: 55px;
+        }
+      }
+    
+      p{
+        margin-top: 15px;
+        font: normal normal normal 16px/25px $defaltFont;
+        overflow: hidden;
+
+        @media screen and (max-width: 768px) {
+          margin-top: 5px;
+          height: 49px; 
+        }
+      }
+    }
+  }
+  
+  
+}

--- a/src/pages/feed/FeedMain/components/Contents/Contents.js
+++ b/src/pages/feed/FeedMain/components/Contents/Contents.js
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import './Contents.scss';
+
+function Contents({ runFunction }) {
+  return (
+    <article className="Contents">
+      <h2>categoryname</h2>
+      <div className="post">
+        <div className="addition">
+          <span>user_id</span>
+          <span>created_at(2020)</span>
+        </div>
+        <h3>아라미 바부</h3>
+        <p>contents</p>
+      </div>
+    </article>
+  );
+}
+
+export default Contents;

--- a/src/pages/feed/FeedMain/components/Contents/Contents.scss
+++ b/src/pages/feed/FeedMain/components/Contents/Contents.scss
@@ -1,0 +1,77 @@
+@import "/src/styles/common.scss";
+
+.Contents{
+  width: 864px;
+  height: 179px;
+  padding: 20px;
+  margin-bottom: 30px;
+  border: 1px solid #E1E4E7;
+  border-radius: 5px;
+
+  @media screen and (max-width: 768px) {
+    width: $mobileWidth;
+    height: 179px;
+    padding: $mobilePadding;
+    margin-bottom: 10px;
+    box-shadow: 0px 5px 10px #0000000D;
+    border: none;
+    border-radius: 0;
+  }
+  
+  h2{
+    padding-bottom: 10px;
+    color:#7E848A;
+    border-bottom: 1px solid #E1E4E7;
+    font: normal normal normal 13px/25px $defaltFont;
+
+    @media screen and (max-width: 768px) {
+      font-size: 13px;
+    }
+  }
+
+  .addition{
+    display: flex;
+    margin-top: 10px;
+    font: normal normal normal 13px/25px $defaltFont;
+
+    @media screen and (max-width: 768px) {
+      margin-top: 20px;
+    }
+
+    span{
+      padding-right: 10px;
+
+      &:first-child{
+        color: $defaltGreenColor;
+        border-right: 1px solid #E1E4E7 ;
+
+        @media screen and (max-width: 768px) {
+          border-right: none;
+        }
+      }
+      &:nth-child(2){
+        padding-left: 10px;
+
+        @media screen and (max-width: 768px) {
+          display: none;
+        }
+      }
+    }
+  }
+
+  h3{
+    margin-top:10px;
+    font: normal normal bold 18px/28px $defaltFont;
+    overflow: hidden;
+
+  }
+
+  p{
+    font: normal normal normal 16px/25px $defaltFont;
+    overflow: hidden;
+
+    @media screen and (max-width: 768px) {
+      font-size: 16px;
+    }
+  }
+}

--- a/src/pages/feed/components/GreenBtn/GreenBtn.js
+++ b/src/pages/feed/components/GreenBtn/GreenBtn.js
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import './GreenBtn.scss';
+
+function GreenBtn({ runFunction, btnName }) {
+  return (
+    <div className="GreenBtn">
+      <button onClick={runFunction}>{btnName}</button>
+    </div>
+  );
+}
+
+export default GreenBtn;

--- a/src/pages/feed/components/GreenBtn/GreenBtn.scss
+++ b/src/pages/feed/components/GreenBtn/GreenBtn.scss
@@ -1,0 +1,14 @@
+@import "/src/styles/common.scss";
+
+.GreenBtn{
+
+  button{
+    width: 235px;
+    height: 60px;
+    background-color: $defaltGreenColor;
+    font-size: 22px;
+    font-style: $defaltFont;
+    color: $defaltWhiteColor;
+    border-radius: 5px;
+  }
+}

--- a/src/pages/feed/components/SortBtn/SortBtn.js
+++ b/src/pages/feed/components/SortBtn/SortBtn.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import './SortBtn.scss';
+
+function SortBtn({ runFunction, btnName, name, selectedAscending }) {
+  return (
+    <div className="SortBtn">
+      <div className={`Dot ${selectedAscending && 'green'}`}></div>
+      <button
+        name={name}
+        className={`${selectedAscending && 'green'}`}
+        onClick={runFunction}
+      >
+        {btnName}
+      </button>
+    </div>
+  );
+}
+
+export default SortBtn;

--- a/src/pages/feed/components/SortBtn/SortBtn.scss
+++ b/src/pages/feed/components/SortBtn/SortBtn.scss
@@ -1,0 +1,26 @@
+@import "/src/styles/common.scss";
+
+.SortBtn{
+  display: flex;
+  align-items: center;
+
+  .Dot{
+    width: 6px;
+    height: 6px;
+    background-color: #ADB5BD;
+    border-radius: 5px;
+
+    &.green {
+      background-color: $defaltGreenColor;
+    }
+  }
+  
+  button{
+    color:#ADB5BD;
+    font-size: 13px;
+
+    &.green {
+      color: #495057;
+    }
+  }
+}

--- a/src/styles/Common.scss
+++ b/src/styles/Common.scss
@@ -32,5 +32,8 @@
 }
 
 
-$defaltBackColor: #ffffff;
+$defaltWhiteColor: #ffffff;
+$defaltGreenColor: #00c854;
 $defaltFont: SpoqaHanSans;
+$mobileWidth: 375px;
+$mobilePadding: 25px 15px;

--- a/src/styles/Reset.scss
+++ b/src/styles/Reset.scss
@@ -18,6 +18,7 @@ time, mark, audio, video {
 	font: inherit;
 	vertical-align: baseline;
   background: #ffffff ;
+	box-sizing: border-box;
 }
 
 article, aside, details, figcaption, figure, 


### PR DESCRIPTION
[완료한 작업]
1. Feed Main Page 반응형 레이아웃 구현 완료
2. 글리스트, 필터 카테고리, 광고리스트 data 서버로부터 get하여 useState에 저장
3. 정렬 버튼 component 와 초록색 버튼 component 분리

[다음 작업]
1. 선택한 카테고리별로 데이터를 받아올 수 있게 필터 모달 구현
2. 데이터에 따른 컨텐츠 종류와 개수 필터 기능 추가
3. 정렬기능
4. 인피니티 스크롤 